### PR TITLE
Fix Build system

### DIFF
--- a/configurations/rollup.config.js
+++ b/configurations/rollup.config.js
@@ -21,7 +21,7 @@ export const plugins = (packageDir) => {
     ts({}), // Generate type definitions files `*.dt.ts`
     esbuild({
       sourceMap: true,
-      target: "ES2020",
+      target: "node16",
       tsconfig: path.join(packageDir, "tsconfig.json")
     }),
     json()


### PR DESCRIPTION
# What?
I think ESBuild build step is broken because are some dependencies that are not transpiled to common JS. I think [the dependencies in this issue](https://github.com/andresgutgon/remix-storage/issues/6)